### PR TITLE
Update CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 0.1.1
+cff-version: 1.2.0
 message: "If you use this software, please cite it using the following metadata."
 title: "Polygeist: Raising C to Polyhedral MLIR"
 authors: 


### PR DESCRIPTION
Hi there, I just noticed this tiny error when browsing through CITATION.cff files on GitHub. Just to clarify: `cff-version` is used to specify which version of the Citation File Format the file is written in; `version` is used to specify the version of your software or dataset.

I changed cff-version to 1.2.0 (specs are [here](https://zenodo.org/record/5171937)).

Hope this helps,
-Jurriaan